### PR TITLE
Clear string scope for subexpressions within strings

### DIFF
--- a/PowerShell.sublime-syntax
+++ b/PowerShell.sublime-syntax
@@ -524,6 +524,7 @@ contexts:
       push:
         - clear_scopes: 1
         - meta_scope: meta.interpolation.powershell
+        - meta_content_scope: source.powershell.embedded
         - match: \)
           scope: punctuation.section.interpolation.end.powershell
           pop: true

--- a/PowerShell.sublime-syntax
+++ b/PowerShell.sublime-syntax
@@ -42,7 +42,7 @@ contexts:
     - include: redirection
     - include: commands
     - include: variable
-    - include: interpolated-string-content
+    - include: group
     - include: function
     - include: attribute
     - include: using-directive
@@ -427,17 +427,16 @@ contexts:
     - match: \@"(?=$)
       scope: punctuation.definition.string.begin.powershell
       push:
-        - meta_scope: string.quoted.double.heredoc.powershell
+        - meta_scope: meta.string.powershell string.quoted.double.heredoc.powershell
         - match: ^"@
           scope: punctuation.definition.string.end.powershell
           pop: true
-        - include: variable-no-property
         - include: escape-characters
         - include: interpolation
     - match: \@'(?=$)
       scope: punctuation.definition.string.begin.powershell
       push:
-        - meta_scope: string.quoted.single.heredoc.powershell
+        - meta_scope: meta.string.powershell string.quoted.single.heredoc.powershell
         - match: ^'@
           scope: punctuation.definition.string.end.powershell
           pop: true
@@ -448,7 +447,7 @@ contexts:
     - match: \'
       scope: punctuation.definition.string.begin.powershell
       push:
-        - meta_scope: string.quoted.single.powershell
+        - meta_scope: meta.string.powershell string.quoted.single.powershell
         - match: "''"
           scope: constant.character.escape.powershell
         - match: \'
@@ -459,7 +458,7 @@ contexts:
     - match: '"'
       scope: punctuation.definition.string.begin.powershell
       push:
-        - meta_scope: string.quoted.double.powershell
+        - meta_scope: meta.string.powershell string.quoted.double.powershell
         - match: '""'
           scope: constant.character.escape.powershell
         - include: escape-characters
@@ -467,8 +466,6 @@ contexts:
           scope: punctuation.definition.string.end.powershell
           pop: true
         - match: '(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,64}\b'
-        - include: variable-no-property
-        - include: variable
         - include: interpolation
         - match: '`\s*$'
           scope: keyword.other.powershell
@@ -511,31 +508,34 @@ contexts:
         - include: script-block
         - include: main
 
-  interpolated-string-content:
+  group:
     - match: \(
       scope: punctuation.section.group.begin.powershell
       push:
-        - meta_content_scope: interpolated.simple.source.powershell
+        - meta_scope: meta.group.powershell
         - match: \)
           scope: punctuation.section.group.end.powershell
           pop: true
         - include: main
-        - include: interpolation
-        - include: interpolated-string-content
 
   interpolation:
-    - match: (\$)(\()
-      captures:
-        1: punctuation.definition.variable.powershell
-        2: punctuation.section.group.begin.powershell
+    - match: \$\(
+      scope: punctuation.section.interpolation.begin.powershell
       push:
-        - meta_content_scope: interpolated.complex.source.powershell
+        - clear_scopes: 1
+        - meta_scope: meta.interpolation.powershell
         - match: \)
-          scope: punctuation.section.group.end.powershell
+          scope: punctuation.section.interpolation.end.powershell
           pop: true
         - include: main
-        - include: interpolation
-        - include: interpolated-string-content
+    - match: (?=\$)
+      push:
+        - clear_scopes: 1
+        - meta_scope: meta.interpolation.powershell
+        - include: variable-no-property
+        - include: variable
+        - match: ''
+          pop: true
 
   numeric-constant:
     - match: \b((0[xX])[\h_]*\h({{integer_suffix}})?)({{bytes_unit}})?\b

--- a/Tests/syntax_test_PowerShell.ps1
+++ b/Tests/syntax_test_PowerShell.ps1
@@ -163,28 +163,31 @@ $variable.Name.Method( )
 # In double-quoted strings, only the variable should be highlighted, not the property
 "This is my $variable.Name!"
 # <- punctuation.definition.string.begin
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+#^^^^^^^^^^^ meta.string string.quoted.double
+#           ^^^^^^^^^ meta.interpolation variable.other.readwrite - string
 #           ^ punctuation.definition.variable
-#            ^^^^^^^^ variable.other.readwrite
-#                    ^^^^^ - variable - punctuation
+#                    ^^^^^^ meta.string string.quoted.double - meta.interpolation - variable - punctuation
 #                          ^ punctuation.definition.string.end
 
 # When used in a subexpression, both should be highlighted
 "This is my $($variable.Name)!"
 # <- punctuation.definition.string.begin
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+#^^^^^^^^^^^ meta.string string.quoted.double
+#           ^^^^^^^^^^^^^^^^^ meta.string meta.interpolation - string
+#                            ^^ meta.string string.quoted.double - meta.interpolation
+#           ^^ punctuation.section.interpolation.begin
+#             ^^^^^^^^^ variable.other.readwrite
 #             ^ punctuation.definition.variable
-#            ^ punctuation.section.group.begin
-#                           ^ punctuation.section.group.end
-#              ^^^^^^^^ variable.other.readwrite
 #                      ^ punctuation.accessor.dot
 #                       ^^^^ variable.other.member
+#                           ^ punctuation.section.interpolation.end
 #                             ^ punctuation.definition.string.end
 
 # $ENV:ComputerName should be highlighted
 "This is the name of my computer: $ENV:ComputerName"
 # <- punctuation.definition.string.begin
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.double
+#                                 ^^^^^^^^^^^^^^^^^ meta.string meta.interpolation - string
 #                                 ^ punctuation.definition.variable
 #                                  ^^^^ support.variable.drive
 #                                      ^^^^^^^^^^^^ variable.other.readwrite
@@ -193,7 +196,8 @@ $variable.Name.Method( )
 # Here as well
 "This is the name of my computer: ${ENV:ComputerName}"
 # <- punctuation.definition.string.begin
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.double
+#                                 ^^^^^^^^^^^^^^^^^^^ meta.string meta.interpolation - string
 #                                 ^ punctuation.definition.variable
 #                                  ^ punctuation.section.braces.begin
 #                                   ^^^^ support.variable.drive
@@ -402,42 +406,43 @@ $a3[1..2]
 
 # Single quoted strings
     'This is a single quoted string.'
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.single
     '$This is a single ''quoted'' string.'
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.single
 #                      ^^ constant.character.escape
 #                              ^^ constant.character.escape
     'This is a
     single quoted string.'
-#   ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single
+#   ^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.single
     'This #also'
-#   ^^^^^^^^^^^^ string.quoted.single
+#   ^^^^^^^^^^^^ meta.string string.quoted.single
     '$(Invoke-Something)'
-#   ^^^^^^^^^^^^^^^^^^^^^ string.quoted.single - meta - variable - support
+#   ^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.single - meta.interpolation - variable - support
     'This "string" is nice.'
-#   ^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single
+#   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.single
 
 # Double quoted strings
     "This is a double quoted string."
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.double
     "$This is a double ""quoted"" string."
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
-#    ^^^^^ variable.language
+#   ^ meta.string string.quoted.double
+#    ^^^^^ meta.string meta.interpolation variable.language - string
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.double - meta.interpolation
 #                      ^^ constant.character.escape
 #                              ^^ constant.character.escape
     "This is a
     double quoted string."
-#   ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+#   ^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.double
     "This #also"
-#   ^^^^^^^^^^^^ string.quoted.double
+#   ^^^^^^^^^^^^ meta.string string.quoted.double
     "$(Invoke-Something)"
-#   ^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
-#    ^ punctuation.definition.variable
-#     ^ punctuation.section.group.begin
-#      ^ interpolated.complex.source support.function
-#                      ^ punctuation.section.group.end
+#   ^ meta.string string.quoted.double
+#    ^^^^^^^^^^^^^^^^^^^ meta.string meta.interpolation - string
+#    ^^ punctuation.section.interpolation.begin
+#      ^^^^^^^^^^^^^^^^ support.function
+#                      ^ punctuation.section.interpolation.end
     "This 'string' is nice."
-#   ^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+#   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.double
 
 # Double quoted here-string
 @"
@@ -1376,7 +1381,7 @@ $file = join-path $env:SystemDrive "$([System.io.path]::GetRandomFileName()).ps1
 #            ^ support.function
 #                  ^ support.variable.drive
 #                         ^ variable.other.readwrite
-#                                   ^ string.quoted.double punctuation.definition.variable
+#                                   ^^ meta.string meta.interpolation punctuation.section.interpolation.begin
 #                                        ^ storage.type
 #                                                       @@@@@@@@@@@@@@@@@ reference
 $ScriptBlock | Out-File $file -Force
@@ -1423,7 +1428,7 @@ get-thing | Out-WithYou > $null # destroy
 #             ^^ constant.character.escape
 #                                   ^^^^^^^^^^^^^^^^^^^ - constant
 "When you call a method: $( get-number | %{ invoke-command $( [string]::format("Like (this{0})","what?") ) $var } )"
-#                        ^ punctuation.definition.variable
+#                        ^^ punctuation.section.interpolation.begin
 #                                      ^ keyword.operator.logical.pipe
 #                                                           ^ meta.group.complex.subexpression punctuation.section.group.begin
 #                                                              ^^^^^^ storage.type
@@ -1435,8 +1440,8 @@ get-thing | Out-WithYou > $null # destroy
 #                                                                                                        ^ meta.group.complex.subexpression punctuation.section.group.end
 #                                                                                                          ^ punctuation.definition.variable
 "This is the DebugPreference variable: $DebugPreference"
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
-#                                      ^^^^^^^^^^^^^^^^ variable.language
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.double
+#                                      ^^^^^^^^^^^^^^^^ meta.string meta.interpolation variable.language - string
 
  $ConfirmPreference $DebugPreference $ErrorActionPreference $ErrorView
 #^ variable.language punctuation

--- a/Tests/syntax_test_PowerShell.ps1
+++ b/Tests/syntax_test_PowerShell.ps1
@@ -1432,7 +1432,8 @@ get-thing | Out-WithYou > $null # destroy
 #             ^^ constant.character.escape
 #                                   ^^^^^^^^^^^^^^^^^^^ - constant
 "When you call a method: $( get-number | %{ invoke-command $( [string]::format("Like (this{0})","what?") ) $var } )"
-#                        ^^ punctuation.section.interpolation.begin
+#                        ^^ punctuation.section.interpolation.begin - source.powershell.embedded
+#                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.powershell.embedded
 #                                      ^ keyword.operator.logical.pipe
 #                                                           ^ meta.group.complex.subexpression punctuation.section.group.begin
 #                                                              ^^^^^^ storage.type
@@ -1443,6 +1444,7 @@ get-thing | Out-WithYou > $null # destroy
 #                                                                                                      ^ meta.group.complex.subexpression punctuation.section.arguments.end
 #                                                                                                        ^ meta.group.complex.subexpression punctuation.section.group.end
 #                                                                                                          ^ punctuation.definition.variable
+#                                                                                                                 ^ punctuation.section.interpolation.end - source.powershell.embedded
 "This is the DebugPreference variable: $DebugPreference"
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.double
 #                                      ^^^^^^^^^^^^^^^^ meta.string meta.interpolation variable.language - string

--- a/Tests/syntax_test_PowerShell.ps1
+++ b/Tests/syntax_test_PowerShell.ps1
@@ -163,18 +163,20 @@ $variable.Name.Method( )
 # In double-quoted strings, only the variable should be highlighted, not the property
 "This is my $variable.Name!"
 # <- punctuation.definition.string.begin
-#^^^^^^^^^^^ meta.string string.quoted.double
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string
+#^^^^^^^^^^^ string.quoted.double
 #           ^^^^^^^^^ meta.interpolation variable.other.readwrite - string
 #           ^ punctuation.definition.variable
-#                    ^^^^^^ meta.string string.quoted.double - meta.interpolation - variable - punctuation
+#                    ^^^^^^ string.quoted.double - meta.interpolation - variable - punctuation
 #                          ^ punctuation.definition.string.end
 
 # When used in a subexpression, both should be highlighted
 "This is my $($variable.Name)!"
 # <- punctuation.definition.string.begin
-#^^^^^^^^^^^ meta.string string.quoted.double
-#           ^^^^^^^^^^^^^^^^^ meta.string meta.interpolation - string
-#                            ^^ meta.string string.quoted.double - meta.interpolation
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string
+#^^^^^^^^^^^ string.quoted.double
+#           ^^^^^^^^^^^^^^^^^ meta.interpolation - string
+#                            ^^ string.quoted.double - meta.interpolation
 #           ^^ punctuation.section.interpolation.begin
 #             ^^^^^^^^^ variable.other.readwrite
 #             ^ punctuation.definition.variable
@@ -186,8 +188,9 @@ $variable.Name.Method( )
 # $ENV:ComputerName should be highlighted
 "This is the name of my computer: $ENV:ComputerName"
 # <- punctuation.definition.string.begin
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.double
-#                                 ^^^^^^^^^^^^^^^^^ meta.string meta.interpolation - string
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+#                                 ^^^^^^^^^^^^^^^^^ meta.interpolation - string
 #                                 ^ punctuation.definition.variable
 #                                  ^^^^ support.variable.drive
 #                                      ^^^^^^^^^^^^ variable.other.readwrite
@@ -196,8 +199,9 @@ $variable.Name.Method( )
 # Here as well
 "This is the name of my computer: ${ENV:ComputerName}"
 # <- punctuation.definition.string.begin
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.double
-#                                 ^^^^^^^^^^^^^^^^^^^ meta.string meta.interpolation - string
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+#                                 ^^^^^^^^^^^^^^^^^^^ meta.interpolation - string
 #                                 ^ punctuation.definition.variable
 #                                  ^ punctuation.section.braces.begin
 #                                   ^^^^ support.variable.drive
@@ -206,7 +210,7 @@ $variable.Name.Method( )
 
 # The @splat references only work in argument mode, should not highlight in strings
 "This is a @double quoted string."
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string string.quoted.double
 #          ^ - punctuation.definition.variable
 #          ^^^^^^^ - variable
 
@@ -219,7 +223,7 @@ $variable.Name.Method( )
 # Single quotes string
 'This is a string'
 # <- punctuation.definition.string.begin
-#^^^^^^^^^^^^^^^^^ string.quoted.single
+#^^^^^^^^^^^^^^^^^ meta.string string.quoted.single
 #                ^ punctuation.definition.string.end
 
 # Hashtable


### PR DESCRIPTION
... and use the common scope conventions for string interpolations. This enables ST's brackets matching within `$(...)` in strings.

![powershell](https://user-images.githubusercontent.com/6579999/166173188-8f1428d7-1ee9-4706-88f2-981042ef2c72.gif)

Also changed the dubious `interpolated.simple.source.powershell` scope for normal parentheses to `meta.group.powershell`, not sure whether the former scope had any special purpose?