### PR TITLE
Fix `$__` highlighting & add `$PsNativeCommand` variables

### DIFF
--- a/PowerShell.sublime-syntax
+++ b/PowerShell.sublime-syntax
@@ -1437,9 +1437,8 @@ variables:
       | PsNativeCommand (?: ArgumentPassing | UseErrorActionPreference )           # PsNativeCommand*
       | PsDebugContext | PsDefaultParameterValues | PsEmailServer
       | PsModuleAutoloadingPreference | PsSenderInfo
-      | PsSessionApplicationName | PsSessionConfigurationName
-      | PsSessionOption | ErrorView | FormatEnumerationLimit | OFS
-      | OutputEncoding
+      | PsSession (?: ApplicationName | ConfigurationName | Option )               # PsSession*
+      | ErrorView | FormatEnumerationLimit | OFS | OutputEncoding
       )\b
     )
   var_scope_mod: (?i:global|local|private|script|using|workflow)

--- a/PowerShell.sublime-syntax
+++ b/PowerShell.sublime-syntax
@@ -1421,9 +1421,9 @@ variables:
     )\b
   var_language: |-
     (?xi:
-      [$^?_]
+      [$^?]
     | \b(?:
-        Args | ConsoleFileName | Error | Event | EventArgs
+        _ | Args | ConsoleFileName | Error | Event | EventArgs
       | EventSubscriber | ForEach | Input | LastExitCode | Matches
       | MyInvocation | NestedPromptLevel | PsBoundParameters | PsCmdlet
       | PsCulture | PsDebugContext | PsItem | Pwd | Sender | SourceArgs

--- a/PowerShell.sublime-syntax
+++ b/PowerShell.sublime-syntax
@@ -1434,6 +1434,7 @@ variables:
         ) Preference
       | Maximum (?: Alias | Drive | Error | Function | History | Variable ) Count  # Maximum*Count
       | Log (?: Command | Engine | Provider ) (?: Health | Lifecycle ) Event       # Log*Event
+      | PsNativeCommand (?: ArgumentPassing | UseErrorActionPreference )           # PsNativeCommand*
       | PsDebugContext | PsDefaultParameterValues | PsEmailServer
       | PsModuleAutoloadingPreference | PsSenderInfo
       | PsSessionApplicationName | PsSessionConfigurationName


### PR DESCRIPTION
_Note: This PR is targeting the refactor branch._

Because `_` is considered an alphanumeric character, it is not matched by `\b`. This means that it can be moved into the non-capture group that is surrounded by `\b`. This will make it so something like `$___` doesn't have the `$_` portion of it turned orange and italic.