### PR TITLE
Restrict herestring bindings

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -16,8 +16,9 @@
         },
         "context": [
             { "key": "selection_empty", "match_all": true },
-            { "key": "selector", "operand": "source.powershell - string", "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "@", "match_all": true },
+            { "key": "selector", "operand": "source.powershell - comment - string", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "@$", "match_all": true },
+            { "key": "following_text", "operator": "not_regex_contains", "operand": "^[\"@]", "match_all": true },
         ]
     },
     {
@@ -37,8 +38,9 @@
         },
         "context": [
             { "key": "selection_empty", "match_all": true },
-            { "key": "selector", "operand": "source.powershell - string", "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "@", "match_all": true },
+            { "key": "selector", "operand": "source.powershell - comment - string", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "@$", "match_all": true },
+            { "key": "following_text", "operator": "not_regex_contains", "operand": "^['@]", "match_all": true },
         ]
     },
 ]


### PR DESCRIPTION
1. don't trigger within comments
2. trigger only directly after `@` character, as otherwise typing quotation mark after `@foo` would also trigger the chain command.
3. trigger only if not directly followed by corresponding quotation or at-sign.